### PR TITLE
Implement security improvements from fork

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ DB_USERNAME=<DB_USERNAME>
 DB_PASSWORD=<DB_PASSWORD>
 
 # JWT secret. Used as raw UTF-8 bytes, so it must be at least 32 characters -
-# shorter values are silently replaced by a hardcoded default. Generate with:
+# the application refuses to start if it is missing or shorter than that. Generate with:
 #   openssl rand -base64 48
 SECRET_KEY=<your-256-bit-secret>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,17 @@ RUN useradd --system --uid 10001 --shell /usr/sbin/nologin app \
  && chown -R app:app /app
 
 COPY --from=build --chown=app:app /build/target/*.jar /app/app.jar
+COPY --chown=app:app docker/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
-USER app
 EXPOSE 8080
 
 # Let the JVM size its heap from the container memory limit rather than the host's
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0"
 
-ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]
+# Deliberately still root here (no USER directive): /app/uploads is a bind
+# mount in production, and a fresh/restored host directory won't carry the
+# ownership baked into the image above. entrypoint.sh fixes that mount
+# point's ownership, then drops to the unprivileged app user via setpriv
+# before ever running application code.
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ The backend exposes a set of REST- and WebSocket-based endpoints, organized by a
 
 | Method | Endpoint               | Description                                                      |
 |--------|------------------------|------------------------------------------------------------------|
-| POST   | `/auth/admin/login`    | Authenticate an admin (expert) user and receive a JWT token.    |
+| POST   | `/auth/admin/login`    | Authenticate an admin (expert) user and receive a JWT token. Repeated failed attempts from the same client/username are temporarily rate limited. |
 | POST   | `/auth/user/login`     | Authenticate an anonymous user for chat access and receive a JWT token. |
+| POST   | `/auth/logout`         | Revoke the caller's JWT (Authorization header) so it can no longer be used, even before it naturally expires. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Mushroom Identification Backend
 
-This is the backend for the Mushroom Identification System – a RESTful service built using Spring Boot. It allows users to submit mushrooms for expert review and enables admins to manage and classify those submissions.
+This is the backend for the Mushroom Identification System - a RESTful service built using Spring Boot. It allows users to submit mushrooms for expert review and enables admins to manage and classify those submissions.
 
 >For an in depth description of the application please visit our [WIKI](https://github.com/jensmjahle/mushroom-identification-backend/wiki).
 ---
@@ -49,25 +49,25 @@ This is the backend for the Mushroom Identification System – a RESTful service
 
 ```
 src/
-├── main/
-│   ├── java/ntnu/idi/mushroomidentificationbackend/
-│   │   ├── config/
-│   │   ├── controller/
-│   │   ├── dto/
-│   │   ├── exception/
-│   │   ├── handler/
-│   │   ├── listener/
-│   │   ├── mapper/
-│   │   ├── model/
-│   │   ├── repository/
-│   │   ├── security/
-│   │   ├── service/
-│   │   ├── task/
-│   │   ├── util/
-│   ├── resources/
-│       ├── application.properties
-│       ├── application-dev.properties
-│       ├── static/
++-- main/
+|   +-- java/ntnu/idi/mushroomidentificationbackend/
+|   |   +-- config/
+|   |   +-- controller/
+|   |   +-- dto/
+|   |   +-- exception/
+|   |   +-- handler/
+|   |   +-- listener/
+|   |   +-- mapper/
+|   |   +-- model/
+|   |   +-- repository/
+|   |   +-- security/
+|   |   +-- service/
+|   |   +-- task/
+|   |   +-- util/
+|   +-- resources/
+|       +-- application.properties
+|       +-- application-dev.properties
+|       +-- static/
 ```
 
 ## Running Locally
@@ -213,7 +213,7 @@ The backend exposes a set of REST- and WebSocket-based endpoints, organized by a
 
 | Method | Endpoint                                     | Description                                                    |
 |--------|----------------------------------------------|----------------------------------------------------------------|
-| POST   | `/api/stats/registration-button-press`       | Record a “registration” button press for analytics purposes.   |
+| POST   | `/api/stats/registration-button-press`       | Record a "registration" button press for analytics purposes.   |
 
 ---
 
@@ -224,9 +224,9 @@ The backend exposes a set of REST- and WebSocket-based endpoints, organized by a
 | Method | Endpoint                            | Description                                                      |
 |--------|-------------------------------------|------------------------------------------------------------------|
 | GET    | `/api/admin/me`                     | Retrieve the profile of the currently authenticated admin.       |
-| PUT    | `/api/admin/profile`                | Update the authenticated admin’s profile details.                |
-| PUT    | `/api/admin/password`               | Change the authenticated admin’s password.                       |
-| DELETE | `/api/admin/delete`                 | Delete the authenticated admin’s own account.                    |
+| PUT    | `/api/admin/profile`                | Update the authenticated admin's profile details.                |
+| PUT    | `/api/admin/password`               | Change the authenticated admin's password.                       |
+| DELETE | `/api/admin/delete`                 | Delete the authenticated admin's own account.                    |
 
 #### Superuser Operations
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+if [ "$(id -u)" = "0" ]; then
+  # /app/uploads is bind-mounted from the host in production. A fresh or
+  # restored host directory won't carry the ownership baked into the image
+  # at build time, so fix the mount point here before dropping privileges.
+  # Only the mount point itself needs this - files and directories the app
+  # creates from here on inherit correct ownership automatically, since it
+  # runs as the app user from this point onward.
+  [ -d /app/uploads ] && chown app:app /app/uploads
+  exec setpriv --reuid=app --regid=app --init-groups java $JAVA_OPTS -jar /app/app.jar
+else
+  exec java $JAVA_OPTS -jar /app/app.jar
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/MushroomIdentificationBackendApplication.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/MushroomIdentificationBackendApplication.java
@@ -23,7 +23,7 @@ public class MushroomIdentificationBackendApplication {
       logger.info("Loading .env file for local development");
       dotenv = Dotenv.load();
     } else {
-      logger.info(".env file not found — assuming real environment variables are set");
+      logger.info(".env file not found - assuming real environment variables are set");
     }
     // Load environment variables with optional fallback to .env
     setEnvOrFallback("DB_URL", dotenv);

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/config/TomcatServerInfoConfig.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/config/TomcatServerInfoConfig.java
@@ -1,0 +1,37 @@
+package ntnu.idi.mushroomidentificationbackend.config;
+
+import org.apache.catalina.core.StandardHost;
+import org.apache.catalina.valves.ErrorReportValve;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.stereotype.Component;
+
+/**
+ * Prevents the embedded Tomcat's default error page from disclosing the server software and
+ * version (e.g. "Apache Tomcat/10.1.34") in error responses, which can help an attacker identify
+ * known vulnerabilities affecting that specific version.
+ */
+@Component
+public class TomcatServerInfoConfig implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+
+  @Override
+  public void customize(TomcatServletWebServerFactory factory) {
+    factory.addConnectorCustomizers(connector -> connector.setXpoweredBy(false));
+    factory.addContextCustomizers(context -> {
+      if (context.getParent() instanceof StandardHost host) {
+        host.setErrorReportValveClass(SilentErrorReportValve.class.getName());
+      }
+    });
+  }
+
+  /**
+   * An ErrorReportValve that never renders server software/version information or the default
+   * HTML error report body.
+   */
+  public static class SilentErrorReportValve extends ErrorReportValve {
+    public SilentErrorReportValve() {
+      setShowServerInfo(false);
+      setShowReport(false);
+    }
+  }
+}

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/admin/AdminUserRequestController.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/admin/AdminUserRequestController.java
@@ -1,5 +1,9 @@
 package ntnu.idi.mushroomidentificationbackend.controller.admin;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.logging.Logger;
 import lombok.AllArgsConstructor;
 import ntnu.idi.mushroomidentificationbackend.dto.request.ChangeRequestStatusDTO;
@@ -12,6 +16,9 @@ import ntnu.idi.mushroomidentificationbackend.security.JWTUtil;
 import ntnu.idi.mushroomidentificationbackend.service.UserRequestService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,31 +43,38 @@ public class AdminUserRequestController {
   private final SessionRegistry sessionRegistry;
 
   /**
-   * Retrieves all user requests with pagination and optional filtering by status.
-   * 
+   * Retrieves user requests, optionally filtered by status and/or a createdAt date range, sorted and
+   * paginated per the given Pageable (defaulting to sorted by updatedAt, most recent first).
+   *
    * @param status the status of the user requests to filter by, can be null for all requests
    * @param exclude if true, excludes requests with the specified status; if false, includes only those requests
-   * @param pageable the pagination information including page number and size
+   * @param from the start of the createdAt range to filter by (inclusive), or null to not filter by date
+   * @param to the end of the createdAt range to filter by (inclusive), or null to not filter by date
+   * @param unpaged if true, returns every matching request in a single page instead of paginating
+   * @param pageable the pagination and sort information including page number, size, and sort
    * @return ResponseEntity containing a paginated list of UserRequestDTO objects
    */
   @GetMapping
   public ResponseEntity<Page<UserRequestDTO>> getAllRequestsPaginated(
       @RequestParam(required = false) UserRequestStatus status,
       @RequestParam(required = false, defaultValue = "false") boolean exclude,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+      @RequestParam(required = false, defaultValue = "false") boolean unpaged,
+      @PageableDefault(size = 20, sort = "updatedAt", direction = Sort.Direction.DESC)
       Pageable pageable
   ) {
-    logger.info(() -> String.format("Request for user requests - page: %d, size: %d, status: %s, exclude: %s",
-        pageable.getPageNumber(), pageable.getPageSize(), status, exclude));
+    logger.info(() -> String.format(
+        "Request for user requests - page: %d, size: %d, sort: %s, status: %s, exclude: %s, from: %s, to: %s, unpaged: %s",
+        pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort(), status, exclude, from, to, unpaged));
 
-    if (status != null) {
-      if (exclude) {
-        return ResponseEntity.ok(userRequestService.getPaginatedRequestsExcludingStatus(status, pageable));
-      } else {
-        return ResponseEntity.ok(userRequestService.getPaginatedRequestsByStatus(status, pageable));
-      }
-    }
+    Date fromDate = from == null ? null : Date.from(from.atStartOfDay(ZoneId.systemDefault()).toInstant());
+    Date toDate = to == null ? null
+        : Date.from(to.atTime(LocalTime.MAX).atZone(ZoneId.systemDefault()).toInstant());
+    Pageable effectivePageable = unpaged ? Pageable.unpaged(pageable.getSort()) : pageable;
 
-    return ResponseEntity.ok(userRequestService.getPaginatedUserRequests(pageable));
+    return ResponseEntity.ok(
+        userRequestService.getFilteredUserRequests(status, exclude, fromDate, toDate, effectivePageable));
   }
 
   /**

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/admin/AdminUserRequestController.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/admin/AdminUserRequestController.java
@@ -130,6 +130,23 @@ public class AdminUserRequestController {
   }
 
   /**
+   * Forcibly releases a user request from whichever admin currently owns it and puts it back
+   * into the queue. Superuser-only: lets a superuser reclaim a request whose assigned
+   * moderator has stopped responding, without needing to be the current owner themselves.
+   *
+   * @param userRequestId the ID of the user request to release
+   * @return ResponseEntity containing a confirmation message
+   */
+  @PostMapping("/{userRequestId}/release")
+  public ResponseEntity<String> releaseRequest(@PathVariable String userRequestId) {
+    logger.info(() -> String.format("Received request to force-release user request %s", userRequestId));
+    userRequestService.forceReleaseRequest(userRequestId);
+    webSocketNotificationHandler.sendRequestUpdateToObservers(userRequestId, WebsocketNotificationType.STATUS_CHANGED);
+    webSocketNotificationHandler.sendRequestUpdateToObservers(userRequestId, WebsocketNotificationType.ADMIN_LEFT_REQUEST);
+    return ResponseEntity.ok("The request was released and placed back into the queue.");
+  }
+
+  /**
    * Retrieves the next user request from the queue.
    * This endpoint is used to fetch the next user request
    * that is currently under review.

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestController.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestController.java
@@ -52,6 +52,7 @@ public class UserRequestController {
   public ResponseEntity<String> createUserRequest(@Valid @ModelAttribute NewUserRequestDTO newUserRequestDTO) {
     logger.info("Received new user request");
     String referenceCode = userRequestService.processNewUserRequest(newUserRequestDTO);
+    webSocketNotificationHandler.sendAdminBroadcast(WebsocketNotificationType.NEW_REQUEST_IN_QUEUE);
     return ResponseEntity.ok(referenceCode);
   }
 

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestController.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestController.java
@@ -1,6 +1,7 @@
 package ntnu.idi.mushroomidentificationbackend.controller.api;
 
 
+import jakarta.validation.Valid;
 import java.util.logging.Logger;
 import ntnu.idi.mushroomidentificationbackend.dto.request.NewUserRequestDTO;
 import ntnu.idi.mushroomidentificationbackend.dto.response.UserRequestDTO;
@@ -48,7 +49,7 @@ public class UserRequestController {
    * @return ResponseEntity containing the reference code for the new user request
    */
   @PostMapping("/create")
-  public ResponseEntity<String> createUserRequest(@ModelAttribute NewUserRequestDTO newUserRequestDTO) {
+  public ResponseEntity<String> createUserRequest(@Valid @ModelAttribute NewUserRequestDTO newUserRequestDTO) {
     logger.info("Received new user request");
     String referenceCode = userRequestService.processNewUserRequest(newUserRequestDTO);
     return ResponseEntity.ok(referenceCode);

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/auth/AuthenticationController.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/auth/AuthenticationController.java
@@ -1,10 +1,16 @@
 package ntnu.idi.mushroomidentificationbackend.controller.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Date;
 import java.util.logging.Logger;
 import ntnu.idi.mushroomidentificationbackend.dto.request.UserLoginDTO;
 import ntnu.idi.mushroomidentificationbackend.dto.response.AuthResponseDTO;
+import ntnu.idi.mushroomidentificationbackend.security.JWTUtil;
+import ntnu.idi.mushroomidentificationbackend.security.LoginAttemptService;
+import ntnu.idi.mushroomidentificationbackend.security.TokenBlocklistService;
 import ntnu.idi.mushroomidentificationbackend.service.AuthenticationService;
 import ntnu.idi.mushroomidentificationbackend.dto.request.LoginRequestDTO;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,26 +24,47 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/auth")
 public class AuthenticationController {
   private final AuthenticationService authenticationService;
+  private final LoginAttemptService loginAttemptService;
+  private final JWTUtil jwtUtil;
+  private final TokenBlocklistService tokenBlocklistService;
+  private static final String BEARER = "Bearer ";
   private final Logger logger = Logger.getLogger(AuthenticationController.class.getName());
 
-  public AuthenticationController(AuthenticationService authenticationService) {
+  public AuthenticationController(AuthenticationService authenticationService,
+      LoginAttemptService loginAttemptService, JWTUtil jwtUtil,
+      TokenBlocklistService tokenBlocklistService) {
     this.authenticationService = authenticationService;
+    this.loginAttemptService = loginAttemptService;
+    this.jwtUtil = jwtUtil;
+    this.tokenBlocklistService = tokenBlocklistService;
   }
 
   /**
    * Handles admin login requests.
    * This endpoint authenticates an admin user
    * and returns an authentication token.
+   * Repeated failed attempts from the same client for the same username
+   * are temporarily locked out to defend against brute-force attacks.
    *
    * @param loginRequest the login request containing username and password
+   * @param request the HTTP request, used to identify the calling client
    * @return ResponseEntity containing the authentication token
    */
   @PostMapping("/admin/login")
-  public ResponseEntity<AuthResponseDTO> adminLogin(@RequestBody LoginRequestDTO loginRequest) {
+  public ResponseEntity<AuthResponseDTO> adminLogin(@RequestBody LoginRequestDTO loginRequest,
+      HttpServletRequest request) {
     logger.info("Received login request for user: " + loginRequest.getUsername());
-    String authenticatedToken = authenticationService.authenticate(loginRequest.getUsername(),
-        loginRequest.getPassword());
-    return ResponseEntity.ok(new AuthResponseDTO(authenticatedToken));
+    String attemptKey = request.getRemoteAddr() + ":" + loginRequest.getUsername();
+    loginAttemptService.checkAllowed(attemptKey);
+    try {
+      String authenticatedToken = authenticationService.authenticate(loginRequest.getUsername(),
+          loginRequest.getPassword());
+      loginAttemptService.recordSuccess(attemptKey);
+      return ResponseEntity.ok(new AuthResponseDTO(authenticatedToken));
+    } catch (RuntimeException e) {
+      loginAttemptService.recordFailure(attemptKey);
+      throw e;
+    }
   }
 
   /**
@@ -67,5 +94,22 @@ public class AuthenticationController {
       // For security, avoid leaking which part failed
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
+  }
+
+  /**
+   * Logs out the caller by revoking the JWT used to authenticate the request, so it can no
+   * longer be used to access protected endpoints even though it has not yet naturally expired.
+   *
+   * @param authHeader the Authorization header containing the JWT to revoke
+   * @return an empty 200 OK response
+   */
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(@RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+    String token = authHeader.replace(BEARER, "").trim();
+    String tokenId = jwtUtil.extractTokenId(token);
+    Date expiration = jwtUtil.extractExpiration(token);
+    tokenBlocklistService.revoke(tokenId, expiration);
+    logger.info("Token revoked on logout");
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/websocket/ChatWebSocketController.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/controller/websocket/ChatWebSocketController.java
@@ -10,7 +10,10 @@ import ntnu.idi.mushroomidentificationbackend.exception.UnauthorizedAccessExcept
 import ntnu.idi.mushroomidentificationbackend.handler.SessionRegistry;
 import ntnu.idi.mushroomidentificationbackend.handler.WebSocketErrorHandler;
 import ntnu.idi.mushroomidentificationbackend.handler.WebSocketNotificationHandler;
+import ntnu.idi.mushroomidentificationbackend.model.entity.UserRequest;
 import ntnu.idi.mushroomidentificationbackend.model.enums.AdminRole;
+import ntnu.idi.mushroomidentificationbackend.model.enums.MessageSenderType;
+import ntnu.idi.mushroomidentificationbackend.model.enums.UserRequestStatus;
 import ntnu.idi.mushroomidentificationbackend.model.enums.WebsocketNotificationType;
 import ntnu.idi.mushroomidentificationbackend.service.MessageService;
 import ntnu.idi.mushroomidentificationbackend.security.JWTUtil;
@@ -69,10 +72,14 @@ public class ChatWebSocketController {
     try {
       jwtUtil.validateChatroomToken(token, userRequestId);
 
-      if (role.equals(AdminRole.SUPERUSER.toString()) || role.equals(AdminRole.MODERATOR.toString())) {
+      UserRequest userRequest = userRequestService.getUserRequest(userRequestId);
+      boolean isAdminSender = role.equals(AdminRole.SUPERUSER.toString()) || role.equals(AdminRole.MODERATOR.toString());
+
+      // Completed requests stay completed - a reply here shouldn't reopen them or
+      // reassign ownership the way tryLockRequest normally would.
+      if (isAdminSender && userRequest.getStatus() != UserRequestStatus.COMPLETED) {
           userRequestService.tryLockRequest(userRequestId, username);
       }
-
 
       // Save the message
       MessageDTO message = messageService.saveMessage(messageDTO, userRequestId);
@@ -82,9 +89,18 @@ public class ChatWebSocketController {
 
       // Broadcast message to the correct chatroom
       messagingTemplate.convertAndSend("/topic/chatroom/" + userRequestId, message);
-      
+
       // Notify observers about the new message
       webSocketNotificationHandler.sendRequestUpdateToObservers(userRequestId, WebsocketNotificationType.NEW_CHAT_MESSAGE);
+
+      // A user following up on a request the owning admin already completed - let
+      // that admin know directly, since they won't be watching a closed request.
+      if (userRequest.getStatus() == UserRequestStatus.COMPLETED
+          && message.getSenderType() == MessageSenderType.USER
+          && userRequest.getAdmin() != null) {
+        webSocketNotificationHandler.sendAlert(userRequest.getAdmin().getUsername(),
+            "A user replied to a request you completed.", "notification.request.followUp");
+      }
 
     }catch (RequestLockedException e) {
       logger.severe("Request is locked by another admin: " + e.getMessage());

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/dto/request/CreateAdminDTO.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/dto/request/CreateAdminDTO.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import ntnu.idi.mushroomidentificationbackend.model.enums.AdminRole;
 
@@ -31,7 +32,7 @@ public class CreateAdminDTO {
   @Email(message = "Invalid email format")
   private String email;
   
-  @NotBlank(message = "Admin role is required")
+  @NotNull(message = "Admin role is required")
   private AdminRole role;
 
 }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/dto/request/NewMushroomDTO.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/dto/request/NewMushroomDTO.java
@@ -1,5 +1,6 @@
 package ntnu.idi.mushroomidentificationbackend.dto.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,5 +18,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 @Setter
 public class NewMushroomDTO {
+  @NotEmpty(message = "each mushroom must have at least one image")
   private List<MultipartFile> images;
 }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/dto/request/NewUserRequestDTO.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/dto/request/NewUserRequestDTO.java
@@ -1,5 +1,8 @@
 package ntnu.idi.mushroomidentificationbackend.dto.request;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,6 +23,10 @@ import lombok.ToString;
 @Setter
 @ToString
 public class NewUserRequestDTO {
+  @NotBlank(message = "text must not be blank")
   private String text;
+
+  @NotEmpty(message = "at least one mushroom must be provided")
+  @Valid
   private List<NewMushroomDTO> mushrooms;
 }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/dto/response/UserRequestDTO.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/dto/response/UserRequestDTO.java
@@ -29,6 +29,6 @@ public class UserRequestDTO {
   private String username;
   private List<BasketBadgeType> basketSummaryBadges;
   private Map<MushroomStatus, Long> mushroomStatusCounts;
-
+  private boolean hasFollowUp;
 
 }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/dto/response/UserRequestDTO.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/dto/response/UserRequestDTO.java
@@ -2,11 +2,13 @@ package ntnu.idi.mushroomidentificationbackend.dto.response;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import ntnu.idi.mushroomidentificationbackend.model.enums.BasketBadgeType;
+import ntnu.idi.mushroomidentificationbackend.model.enums.MushroomStatus;
 import ntnu.idi.mushroomidentificationbackend.model.enums.UserRequestStatus;
 import org.springframework.lang.Nullable;
 
@@ -26,6 +28,7 @@ public class UserRequestDTO {
   @Nullable
   private String username;
   private List<BasketBadgeType> basketSummaryBadges;
+  private Map<MushroomStatus, Long> mushroomStatusCounts;
 
 
 }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/exception/TooManyRequestsException.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/exception/TooManyRequestsException.java
@@ -1,0 +1,17 @@
+package ntnu.idi.mushroomidentificationbackend.exception;
+
+public class TooManyRequestsException extends RuntimeException {
+
+  public TooManyRequestsException(String message) {
+    super(message);
+  }
+
+  public TooManyRequestsException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public TooManyRequestsException() {
+    super("Too many requests.");
+  }
+
+}

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/handler/GlobalExceptionHandler.java
@@ -1,12 +1,22 @@
 package ntnu.idi.mushroomidentificationbackend.handler;
 
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import ntnu.idi.mushroomidentificationbackend.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-
-import java.util.Map;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 /**
  * Global exception handler to manage all application exceptions.
@@ -14,11 +24,13 @@ import java.util.Map;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
+  private static final Logger logger = Logger.getLogger(GlobalExceptionHandler.class.getName());
+
   /**
    * Builds a standardized response entity for exceptions.
    * This method creates a response entity with a specific HTTP status,
    * a message, and a type.
-   * 
+   *
    * @param status the HTTP status to return
    * @param message the error message to include in the response
    * @param type the type of error (e.g., DATABASE_ERROR, REQUEST_LOCKED, UNAUTHORIZED)
@@ -31,11 +43,87 @@ public class GlobalExceptionHandler {
     ));
   }
 
+  /**
+   * Handles any exception not covered by a more specific handler below. The exception detail is
+   * logged server-side only: returning it to the client would leak internal implementation
+   * details (stack traces, library/server info, SQL, etc.) that can help an attacker.
+   */
   @ExceptionHandler(Exception.class)
   public ResponseEntity<Map<String, String>> handleGeneralException(Exception e) {
+    logger.log(Level.SEVERE, "Unhandled exception", e);
     return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR,
-        "An unexpected error occurred: " + e.getMessage(),
+        "An unexpected error occurred.",
         "INTERNAL_SERVER_ERROR");
+  }
+
+  /**
+   * Handles malformed request bodies (invalid JSON, wrong types, etc.), which previously fell
+   * through to the generic 500 handler.
+   */
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<Map<String, String>> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException e) {
+    return buildResponse(HttpStatus.BAD_REQUEST,
+        "Malformed request body.",
+        "MALFORMED_REQUEST");
+  }
+
+  /**
+   * Handles requests sent with a Content-Type the endpoint does not support, which previously
+   * fell through to the generic 500 handler instead of the correct 415 response.
+   */
+  @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+  public ResponseEntity<Map<String, String>> handleHttpMediaTypeNotSupportedException(
+      HttpMediaTypeNotSupportedException e) {
+    return buildResponse(HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+        "Unsupported content type.",
+        "UNSUPPORTED_MEDIA_TYPE");
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<Map<String, String>> handleMissingServletRequestParameterException(
+      MissingServletRequestParameterException e) {
+    return buildResponse(HttpStatus.BAD_REQUEST,
+        "Missing required parameter: " + e.getParameterName(),
+        "MISSING_PARAMETER");
+  }
+
+  @ExceptionHandler(MissingServletRequestPartException.class)
+  public ResponseEntity<Map<String, String>> handleMissingServletRequestPartException(
+      MissingServletRequestPartException e) {
+    return buildResponse(HttpStatus.BAD_REQUEST,
+        "Missing required part: " + e.getRequestPartName(),
+        "MISSING_PARAMETER");
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<Map<String, String>> handleMethodArgumentTypeMismatchException(
+      MethodArgumentTypeMismatchException e) {
+    return buildResponse(HttpStatus.BAD_REQUEST,
+        "Invalid value for parameter: " + e.getName(),
+        "INVALID_INPUT");
+  }
+
+  /**
+   * Handles bean-validation failures on request bodies (@Valid @RequestBody) and on
+   * form/multipart-bound objects (@Valid @ModelAttribute), enforcing server-side business
+   * validation instead of accepting malformed/incomplete submissions.
+   */
+  @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
+  public ResponseEntity<Map<String, String>> handleValidationException(BindException e) {
+    String message = e.getBindingResult().getFieldErrors().stream()
+        .map(FieldError::getDefaultMessage)
+        .collect(Collectors.joining("; "));
+    return buildResponse(HttpStatus.BAD_REQUEST,
+        message.isBlank() ? "Invalid request." : message,
+        "INVALID_INPUT");
+  }
+
+  @ExceptionHandler(TooManyRequestsException.class)
+  public ResponseEntity<Map<String, String>> handleTooManyRequestsException(TooManyRequestsException e) {
+    return buildResponse(HttpStatus.TOO_MANY_REQUESTS,
+        e.getMessage(),
+        "TOO_MANY_REQUESTS");
   }
 
   @ExceptionHandler(DatabaseOperationException.class)

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/handler/GlobalExceptionHandler.java
@@ -192,7 +192,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(UsernameAlreadyExistsException.class)
   public ResponseEntity<Map<String, String>> handleUsernameAlreadyExistsException(UsernameAlreadyExistsException e) {
     return buildResponse(HttpStatus.CONFLICT,
-        "Obs! This username is already taken",
+        "This username is already taken.",
         "USERNAME_CONFLICT");
   }
 

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/handler/WebSocketNotificationHandler.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/handler/WebSocketNotificationHandler.java
@@ -91,4 +91,19 @@ public class WebSocketNotificationHandler {
     ));
   }
 
+  /**
+   * Broadcasts an update to every connected admin/moderator, e.g. to tell open admin
+   * dashboards that a new request has been added to the queue without those clients
+   * needing to poll or be manually refreshed.
+   *
+   * @param type the type of update
+   */
+  public void sendAdminBroadcast(WebsocketNotificationType type) {
+    messagingTemplate.convertAndSend("/topic/admins", Map.of(
+        "type", type.name(),
+        "message", type.getMessage(),
+        "i18n", type.getI18nKey()
+    ));
+  }
+
 }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/mapper/UserRequestMapper.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/mapper/UserRequestMapper.java
@@ -35,6 +35,7 @@ public class UserRequestMapper {
     dto.setBasketSummaryBadges(badges);
     dto.setNumberOfMushrooms(mushroomCount);
     dto.setMushroomStatusCounts(mushroomStatusCounts);
+    dto.setHasFollowUp(userRequest.isHasFollowUp());
     if (userRequest.getAdmin() != null) {
       dto.setUsername(userRequest.getAdmin().getUsername());
     }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/mapper/UserRequestMapper.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/mapper/UserRequestMapper.java
@@ -1,9 +1,11 @@
 package ntnu.idi.mushroomidentificationbackend.mapper;
 
 import java.util.List;
+import java.util.Map;
 import ntnu.idi.mushroomidentificationbackend.dto.response.UserRequestDTO;
 import ntnu.idi.mushroomidentificationbackend.model.entity.UserRequest;
 import ntnu.idi.mushroomidentificationbackend.model.enums.BasketBadgeType;
+import ntnu.idi.mushroomidentificationbackend.model.enums.MushroomStatus;
 
 /**
  * Utility class for mapping UserRequest entities to UserRequestDTOs.
@@ -23,7 +25,8 @@ public class UserRequestMapper {
    * @param userRequest User requests entity.
    * @return |UserRequestWithoutMessagesDTO.
    */
-  public static UserRequestDTO fromEntityToDto(UserRequest userRequest, List<BasketBadgeType> badges, long mushroomCount) {
+  public static UserRequestDTO fromEntityToDto(UserRequest userRequest, List<BasketBadgeType> badges,
+      long mushroomCount, Map<MushroomStatus, Long> mushroomStatusCounts) {
     UserRequestDTO dto = new UserRequestDTO();
     dto.setUserRequestId(userRequest.getUserRequestId());
     dto.setCreatedAt(userRequest.getCreatedAt());
@@ -31,6 +34,7 @@ public class UserRequestMapper {
     dto.setStatus(userRequest.getStatus());
     dto.setBasketSummaryBadges(badges);
     dto.setNumberOfMushrooms(mushroomCount);
+    dto.setMushroomStatusCounts(mushroomStatusCounts);
     if (userRequest.getAdmin() != null) {
       dto.setUsername(userRequest.getAdmin().getUsername());
     }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/model/entity/UserRequest.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/model/entity/UserRequest.java
@@ -52,6 +52,10 @@ public class UserRequest {
   // True when the user has sent a message on this request since it was marked
   // COMPLETED, without the owning admin having replied yet - lets a completed
   // request stay completed while still surfacing a follow-up to its admin.
+  // columnDefinition gives ddl-auto=update a DEFAULT to backfill existing rows
+  // with when adding this NOT NULL column - without it, the ADD COLUMN fails
+  // outright on any table that already has data (as it did in production).
+  @Column(columnDefinition = "boolean not null default false")
   private boolean hasFollowUp;
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "username")

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/model/entity/UserRequest.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/model/entity/UserRequest.java
@@ -49,6 +49,10 @@ public class UserRequest {
   @Temporal(TemporalType.TIMESTAMP)
   private Date updatedAt;
   private UserRequestStatus status;
+  // True when the user has sent a message on this request since it was marked
+  // COMPLETED, without the owning admin having replied yet - lets a completed
+  // request stay completed while still surfacing a follow-up to its admin.
+  private boolean hasFollowUp;
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "username")
   @Exclude

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/model/enums/WebsocketNotificationType.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/model/enums/WebsocketNotificationType.java
@@ -16,7 +16,8 @@ public enum WebsocketNotificationType {
   REQUEST_CURRENTLY_UNDER_REVIEW("The request is currently under review.", "notification.request.currentlyUnderReview"),
   USER_LOGGED_IN("User logged in.", "notification.user.loggedIn"),
   USER_LOGGED_OUT("User logged out.", "notification.user.loggedOut"),
-  ADMIN_LEFT_REQUEST("Admin left the request.", "notification.request.adminLeft");
+  ADMIN_LEFT_REQUEST("Admin left the request.", "notification.request.adminLeft"),
+  NEW_REQUEST_IN_QUEUE("A new request was added to the queue.", "notification.request.newInQueue");
   
   private final String message;
   private final String i18nKey;

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/repository/UserRequestRepository.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/repository/UserRequestRepository.java
@@ -5,14 +5,13 @@ import java.util.List;
 import java.util.Optional;
 import ntnu.idi.mushroomidentificationbackend.model.entity.UserRequest;
 import ntnu.idi.mushroomidentificationbackend.model.enums.UserRequestStatus;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRequestRepository extends JpaRepository<UserRequest, String> {
-  Page<UserRequest> findAllByOrderByUpdatedAtDesc(Pageable pageable);
+public interface UserRequestRepository extends JpaRepository<UserRequest, String>,
+    JpaSpecificationExecutor<UserRequest> {
   Optional<UserRequest> findFirstByStatusAndAdminIsNullOrderByUpdatedAtAsc(UserRequestStatus status);
   Optional<UserRequest> findByPasswordHash(String passwordHash);
   Optional<UserRequest> findByUserRequestId(String userRequestId);
@@ -22,11 +21,5 @@ public interface UserRequestRepository extends JpaRepository<UserRequest, String
   List<UserRequest> findByCreatedAtBetween(Date createdAt, Date createdAt2);
   long countByCreatedAtBetween(Date createdAt, Date createdAt2);
   long countByStatusAndCreatedAtBetween(UserRequestStatus status, Date createdAt, Date createdAt2);
-
-  Page<UserRequest> findAllByStatus(UserRequestStatus status, Pageable pageable);
-  Page<UserRequest> findAllByStatusNot(UserRequestStatus status, Pageable pageable);
   List<UserRequest> findByCreatedAtBefore(Date date);
-
-
-
 }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/repository/UserRequestSpecifications.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/repository/UserRequestSpecifications.java
@@ -1,0 +1,29 @@
+package ntnu.idi.mushroomidentificationbackend.repository;
+
+import java.util.Date;
+import ntnu.idi.mushroomidentificationbackend.model.entity.UserRequest;
+import ntnu.idi.mushroomidentificationbackend.model.enums.UserRequestStatus;
+import org.springframework.data.jpa.domain.Specification;
+
+/**
+ * Reusable {@link Specification} predicates for querying {@link UserRequest} entities,
+ * composed by the admin request table's status/date filters.
+ */
+public final class UserRequestSpecifications {
+
+  private UserRequestSpecifications() {
+    throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+  }
+
+  public static Specification<UserRequest> statusIs(UserRequestStatus status) {
+    return (root, query, cb) -> cb.equal(root.get("status"), status);
+  }
+
+  public static Specification<UserRequest> statusIsNot(UserRequestStatus status) {
+    return (root, query, cb) -> cb.notEqual(root.get("status"), status);
+  }
+
+  public static Specification<UserRequest> createdBetween(Date from, Date to) {
+    return (root, query, cb) -> cb.between(root.get("createdAt"), from, to);
+  }
+}

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/security/JWTAuthorizationFilter.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/security/JWTAuthorizationFilter.java
@@ -21,10 +21,12 @@ import java.util.Collections;
 public class JWTAuthorizationFilter extends OncePerRequestFilter {
 
   private final JWTUtil jwtUtil;
+  private final TokenBlocklistService tokenBlocklistService;
   private final Logger logger = Logger.getLogger(JWTAuthorizationFilter.class.getName());
 
-  public JWTAuthorizationFilter(JWTUtil jwtUtil) {
+  public JWTAuthorizationFilter(JWTUtil jwtUtil, TokenBlocklistService tokenBlocklistService) {
     this.jwtUtil = jwtUtil;
+    this.tokenBlocklistService = tokenBlocklistService;
   }
 
   /**
@@ -52,6 +54,11 @@ public class JWTAuthorizationFilter extends OncePerRequestFilter {
     if (token != null) {
       try {
         if (jwtUtil.isTokenValid(token)) {
+          if (tokenBlocklistService.isRevoked(jwtUtil.extractTokenId(token))) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token has been revoked");
+            return;
+          }
+
           String username = jwtUtil.extractUsername(token);
           String role = jwtUtil.extractRole(token);
 

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/security/JWTUtil.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/security/JWTUtil.java
@@ -11,6 +11,7 @@ import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import ntnu.idi.mushroomidentificationbackend.exception.UnauthorizedAccessException;
@@ -22,7 +23,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class JWTUtil {
 
-  private static final long EXPIRATION_TIME = 86400000; // 1 day
+  // Session tokens are relatively short-lived so that a stolen/leaked token has a smaller
+  // window of usefulness; combined with logout revocation (see TokenBlocklistService) this
+  // limits how long a token remains usable after the user is done with it.
+  private static final long EXPIRATION_TIME = 8 * 60 * 60 * 1000; // 8 hours
   private static final long IMAGE_URL_EXPIRATION = 86400000; // 1 day
   private final Key key;
   private static final Logger logger = Logger.getLogger(JWTUtil.class.getName());
@@ -30,11 +34,13 @@ public class JWTUtil {
   public JWTUtil(SecretsConfig secretsConfig) {
     String secretKey = secretsConfig.getSecretKey();
     if (secretKey == null || secretKey.getBytes(StandardCharsets.UTF_8).length < 32) {
-      logger.severe("SECRET_KEY is too short or missing. Using fallback key. NOTE: This is not secure!");
-      secretKey = "defaultSecretKey-super-duper-key-secrets-yes-defaultSecretKey-super-duper-key-secrets-yes";
+      logger.severe("SECRET_KEY is missing or shorter than 32 bytes.");
+      throw new IllegalStateException(
+          "SECRET_KEY must be configured and at least 32 bytes long. Refusing to start with an "
+              + "insecure or missing JWT signing key.");
     }
 
-    key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
   }
   
   /**
@@ -48,6 +54,7 @@ public class JWTUtil {
    */
   public String generateToken(String username, String role) {
     return Jwts.builder()
+        .setId(UUID.randomUUID().toString())
         .setSubject(username)
         .claim("role", role)
         .setIssuedAt(new Date())
@@ -121,6 +128,27 @@ public class JWTUtil {
    */
   public String extractRole(String token) {
     return extractAllClaims(token).get("role", String.class);
+  }
+
+  /**
+   * Extracts the unique token ID (jti claim) from the JWT token.
+   * Used to identify a specific token for revocation on logout.
+   *
+   * @param token the JWT token
+   * @return the token ID contained in the token
+   */
+  public String extractTokenId(String token) {
+    return extractClaim(token, Claims::getId);
+  }
+
+  /**
+   * Extracts the expiration date from the JWT token.
+   *
+   * @param token the JWT token
+   * @return the expiration date contained in the token
+   */
+  public Date extractExpiration(String token) {
+    return extractClaim(token, Claims::getExpiration);
   }
 
   /**

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/security/LoginAttemptService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/security/LoginAttemptService.java
@@ -1,0 +1,76 @@
+package ntnu.idi.mushroomidentificationbackend.security;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import ntnu.idi.mushroomidentificationbackend.exception.TooManyRequestsException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Tracks failed admin login attempts per client/username combination and applies a temporary
+ * lockout once too many failures occur in a row, to defend against brute-force and credential
+ * stuffing attacks against the admin login endpoint.
+ */
+@Component
+public class LoginAttemptService {
+
+  private static final int MAX_ATTEMPTS = 5;
+  private static final Duration LOCKOUT_DURATION = Duration.ofMinutes(15);
+
+  private final ConcurrentMap<String, Attempts> attemptsByKey = new ConcurrentHashMap<>();
+
+  /**
+   * Checks whether the given key is currently locked out due to too many recent failed attempts.
+   *
+   * @param key an identifier for the caller, e.g. "{clientIp}:{username}"
+   * @throws TooManyRequestsException if the key is currently locked out
+   */
+  public void checkAllowed(String key) {
+    Attempts attempts = attemptsByKey.get(key);
+    if (attempts != null && attempts.isLockedOut()) {
+      throw new TooManyRequestsException(
+          "Too many failed login attempts. Please try again later.");
+    }
+  }
+
+  /**
+   * Records a failed login attempt for the given key, locking it out once the failure count
+   * reaches the configured threshold.
+   *
+   * @param key an identifier for the caller, e.g. "{clientIp}:{username}"
+   */
+  public void recordFailure(String key) {
+    attemptsByKey.compute(key, (k, existing) -> {
+      Attempts attempts = (existing == null || !existing.isWithinWindow()) ? new Attempts() : existing;
+      attempts.failureCount++;
+      if (attempts.failureCount >= MAX_ATTEMPTS) {
+        attempts.lockedUntil = Instant.now().plus(LOCKOUT_DURATION);
+      }
+      return attempts;
+    });
+  }
+
+  /**
+   * Clears any recorded failures for the given key after a successful login.
+   *
+   * @param key an identifier for the caller, e.g. "{clientIp}:{username}"
+   */
+  public void recordSuccess(String key) {
+    attemptsByKey.remove(key);
+  }
+
+  private static final class Attempts {
+    private int failureCount;
+    private Instant lockedUntil;
+    private final Instant windowStart = Instant.now();
+
+    private boolean isLockedOut() {
+      return lockedUntil != null && Instant.now().isBefore(lockedUntil);
+    }
+
+    private boolean isWithinWindow() {
+      return isLockedOut() || Instant.now().isBefore(windowStart.plus(LOCKOUT_DURATION));
+    }
+  }
+}

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/security/SecretsConfig.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/security/SecretsConfig.java
@@ -38,13 +38,16 @@ public class SecretsConfig {
 
   /**
    * Retrieves the secret key used for cryptographic operations.
-   * 
-   * @return the secret key, or a fallback value if not set
+   *
+   * @return the secret key
+   * @throws IllegalStateException if the SECRET_KEY environment variable is not set
    */
   public String getSecretKey() {
     if (secretKey == null || secretKey.isBlank()) {
-      LogHelper.warning(logger, "WARNING: SECRET_KEY not set. Using fallback. NOTE: This is not secure!");
-      return "fallback-secret-key-please-set-in-env-fallback-secret-key-please-set-in-env";
+      LogHelper.severe(logger, "SECRET_KEY not set.");
+      throw new IllegalStateException(
+          "SECRET_KEY must be configured. Refusing to start without a securely configured JWT "
+              + "signing key.");
     }
     return secretKey;
   }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/security/SecurityConfig.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/security/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
             // More specific matchers must be evaluated before the broader /api/** and
             // /admin/** rules below, since Spring Security applies only the first match.
             .requestMatchers("/admin/superuser/**").hasRole(SUPERUSER_ROLE)
+            .requestMatchers("/api/admin/requests/*/release").hasRole(SUPERUSER_ROLE)
             .requestMatchers("/api/admin/**").hasAnyRole(SUPERUSER_ROLE, MODERATOR_ROLE)
             .requestMatchers("/admin/**").hasAnyRole(SUPERUSER_ROLE, MODERATOR_ROLE)
             .requestMatchers("/api/**").hasAnyRole(SUPERUSER_ROLE, MODERATOR_ROLE, USER_ROLE)

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/security/SecurityConfig.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/security/SecurityConfig.java
@@ -43,6 +43,13 @@ public class SecurityConfig {
     http
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authz -> authz
+            // Spring Boot's error controller is reached via an internal Tomcat
+            // dispatch (RequestDispatcher.include) whenever a filter/handler calls
+            // sendError() or an exception escapes normal MVC handling - it re-enters
+            // this same filter chain, without the original request's role in scope.
+            // Without this rule the error dispatch itself gets denied, so callers see
+            // a generic 403 instead of the actual underlying error (401, 400, 500...).
+            .requestMatchers("/error").permitAll()
             .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
             .requestMatchers("/auth/admin/login").permitAll()
             .requestMatchers("/auth/user/login").permitAll()

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/security/SecurityConfig.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/security/SecurityConfig.java
@@ -17,13 +17,15 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final JWTUtil jwtUtil;
+  private final TokenBlocklistService tokenBlocklistService;
   private static final String SUPERUSER_ROLE = "SUPERUSER";
   private static final String MODERATOR_ROLE = "MODERATOR";
   private static final String USER_ROLE = "USER";
 
 
-  public SecurityConfig(JWTUtil jwtUtil) {
+  public SecurityConfig(JWTUtil jwtUtil, TokenBlocklistService tokenBlocklistService) {
     this.jwtUtil = jwtUtil;
+    this.tokenBlocklistService = tokenBlocklistService;
   }
 
   /**
@@ -48,14 +50,17 @@ public class SecurityConfig {
             .requestMatchers("/api/images/**").permitAll()
             .requestMatchers("/api/websocket/**").permitAll()
             .requestMatchers("/api/stats/**").permitAll()
-            .requestMatchers("/api/**").hasAnyRole(SUPERUSER_ROLE, MODERATOR_ROLE, USER_ROLE)
+            // More specific matchers must be evaluated before the broader /api/** and
+            // /admin/** rules below, since Spring Security applies only the first match.
+            .requestMatchers("/admin/superuser/**").hasRole(SUPERUSER_ROLE)
             .requestMatchers("/api/admin/**").hasAnyRole(SUPERUSER_ROLE, MODERATOR_ROLE)
             .requestMatchers("/admin/**").hasAnyRole(SUPERUSER_ROLE, MODERATOR_ROLE)
-            .requestMatchers("/admin/superuser/**").hasRole(SUPERUSER_ROLE)
+            .requestMatchers("/api/**").hasAnyRole(SUPERUSER_ROLE, MODERATOR_ROLE, USER_ROLE)
             .requestMatchers("/ws/**").permitAll()
             .anyRequest().authenticated()
         )
-        .addFilterBefore(new JWTAuthorizationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+        .addFilterBefore(new JWTAuthorizationFilter(jwtUtil, tokenBlocklistService),
+            UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
   }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/security/TokenBlocklistService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/security/TokenBlocklistService.java
@@ -1,0 +1,53 @@
+package ntnu.idi.mushroomidentificationbackend.security;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Tracks JWTs that have been revoked (e.g. via logout) before their natural expiration.
+ * Since the application uses stateless JWTs, this denylist is what makes a token issued
+ * before logout stop being accepted afterward.
+ */
+@Component
+public class TokenBlocklistService {
+
+  private final ConcurrentMap<String, Instant> revokedTokenExpirations = new ConcurrentHashMap<>();
+
+  /**
+   * Marks a token as revoked until its own expiration time. After that point it would be
+   * rejected as expired anyway, so there is no need to keep tracking it.
+   *
+   * @param tokenId the unique ID (jti claim) of the token to revoke
+   * @param expiration the original expiration time of the token
+   */
+  public void revoke(String tokenId, Date expiration) {
+    if (tokenId == null) {
+      return;
+    }
+    revokedTokenExpirations.put(tokenId, expiration.toInstant());
+  }
+
+  /**
+   * Checks whether the given token ID has been revoked.
+   *
+   * @param tokenId the unique ID (jti claim) of the token to check
+   * @return true if the token has been revoked and has not yet naturally expired
+   */
+  public boolean isRevoked(String tokenId) {
+    return tokenId != null && revokedTokenExpirations.containsKey(tokenId);
+  }
+
+  /**
+   * Periodically purges entries for tokens that have since expired naturally, since they no
+   * longer need to be tracked in the denylist.
+   */
+  @Scheduled(fixedRate = 60 * 60 * 1000) // every hour
+  public void purgeExpiredEntries() {
+    Instant now = Instant.now();
+    revokedTokenExpirations.entrySet().removeIf(entry -> entry.getValue().isBefore(now));
+  }
+}

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/security/WebSocketAuthInterceptor.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/security/WebSocketAuthInterceptor.java
@@ -24,10 +24,12 @@ import org.springframework.stereotype.Component;
 public class WebSocketAuthInterceptor implements ChannelInterceptor {
 
   private final JWTUtil jwtUtil;
+  private final TokenBlocklistService tokenBlocklistService;
   private static final Logger logger = Logger.getLogger(WebSocketAuthInterceptor.class.getName());
 
-  public WebSocketAuthInterceptor(JWTUtil jwtUtil) {
+  public WebSocketAuthInterceptor(JWTUtil jwtUtil, TokenBlocklistService tokenBlocklistService) {
     this.jwtUtil = jwtUtil;
+    this.tokenBlocklistService = tokenBlocklistService;
   }
 
   /**
@@ -57,6 +59,10 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
     }
     if (!jwtUtil.isTokenValid(token)) {
       warning(logger, "WebSocket rejected: Invalid or missing token");
+      return null;
+    }
+    if (tokenBlocklistService.isRevoked(jwtUtil.extractTokenId(token))) {
+      warning(logger, "WebSocket rejected: Revoked token");
       return null;
     }
 

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/service/AuthenticationService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/service/AuthenticationService.java
@@ -2,7 +2,6 @@ package ntnu.idi.mushroomidentificationbackend.service;
 
 import ntnu.idi.mushroomidentificationbackend.exception.RequestNotFoundException;
 import ntnu.idi.mushroomidentificationbackend.exception.UnauthorizedAccessException;
-import ntnu.idi.mushroomidentificationbackend.exception.UserNotFoundException;
 import ntnu.idi.mushroomidentificationbackend.model.entity.Admin;
 import ntnu.idi.mushroomidentificationbackend.model.entity.UserRequest;
 import ntnu.idi.mushroomidentificationbackend.repository.AdminRepository;
@@ -18,6 +17,17 @@ import java.util.Optional;
  */
 @Service
 public class AuthenticationService {
+
+  /**
+   * A precomputed BCrypt hash with no known matching plaintext, used to perform a dummy
+   * password comparison when the submitted username does not exist. This keeps the response
+   * time for "unknown username" and "wrong password" cases roughly equal, closing the timing
+   * side-channel that would otherwise let an attacker enumerate valid admin usernames.
+   */
+  private static final String DUMMY_PASSWORD_HASH =
+      "$2a$10$7EqJtq98hPqEX7fNZaFWoOhi5L5DlvmXKfVUP8sxvSbaXTKZ8SWpi";
+  private static final String INVALID_CREDENTIALS_MESSAGE = "Invalid username or password";
+
   private final AdminRepository adminRepository;
   private final JWTUtil jwtUtil;
   private final PasswordEncoder passwordEncoder;
@@ -45,12 +55,15 @@ public class AuthenticationService {
     Optional<Admin> adminOpt = adminRepository.findByUsername(username);
 
     if (adminOpt.isEmpty()) {
-      throw new UserNotFoundException("no such user in database"); // Username not found in the database
+      // Perform a dummy hash comparison so the response takes about as long as a real
+      // password check, and throw the same exception/message as a wrong password would.
+      passwordEncoder.matches(enteredPassword, DUMMY_PASSWORD_HASH);
+      throw new UnauthorizedAccessException(INVALID_CREDENTIALS_MESSAGE);
     }
 
     Admin admin = adminOpt.get();
     if (!passwordEncoder.matches(enteredPassword, admin.getPasswordHash())) {
-      throw new UnauthorizedAccessException("password is incorrect"); // Invalid password
+      throw new UnauthorizedAccessException(INVALID_CREDENTIALS_MESSAGE);
     }
 
     return jwtUtil.generateToken(admin.getUsername(), admin.getRole().toString()); // Authentication successful,

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/service/ImageService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/service/ImageService.java
@@ -1,14 +1,17 @@
 package ntnu.idi.mushroomidentificationbackend.service;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
 import java.util.logging.Logger;
+import javax.imageio.ImageIO;
 import ntnu.idi.mushroomidentificationbackend.exception.ImageProcessingException;
 import ntnu.idi.mushroomidentificationbackend.exception.InvalidImageFormatException;
 import ntnu.idi.mushroomidentificationbackend.util.LogHelper;
+import org.apache.tika.Tika;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,6 +31,7 @@ public class ImageService {
   private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB limit
   private static final Logger logger = Logger.getLogger(ImageService.class.getName());
   private static final String REGEX_SANITIZE = "[^a-zA-Z0-9_-]";
+  private static final Tika TIKA = new Tika();
 
   private ImageService() {
     
@@ -52,17 +56,34 @@ public class ImageService {
       throw new ImageProcessingException("Invalid file: The file is empty.");
     }
 
-    // **Validate file type**
-    String mimeType = file.getContentType();  
-    if (!ALLOWED_MIME_TYPES.contains(mimeType)) {
-      LogHelper.info(logger, "Invalid file type: {0}. Only JPEG and PNG are allowed.", mimeType);
-      throw new InvalidImageFormatException("Invalid file type. Only JPEG and PNG are allowed.");
-    }
-
     // **Check file size**
     if (file.getSize() > MAX_FILE_SIZE) {
       LogHelper.info(logger, "File is too large. Max allowed size is {0}MB and the file was {1}MB", MAX_FILE_SIZE / (1024 * 1024), file.getSize() / (1024 * 1024));
       throw new ImageProcessingException("File is too large. Max allowed size is 10MB.");
+    }
+
+    byte[] content = file.getBytes();
+
+    // **Validate the actual file content, not just the client-supplied filename/Content-Type.**
+    // Detects the real MIME type from the file's magic bytes (signature) so a renamed or
+    // relabelled non-image file cannot masquerade as a JPEG/PNG.
+    String detectedMimeType = TIKA.detect(content);
+    if (!ALLOWED_MIME_TYPES.contains(detectedMimeType)) {
+      LogHelper.info(logger, "Invalid file type: {0}. Only JPEG and PNG are allowed.", detectedMimeType);
+      throw new InvalidImageFormatException("Invalid file type. Only JPEG and PNG are allowed.");
+    }
+
+    // **Confirm the content actually decodes as an image**, rejecting truncated or corrupt
+    // files that merely happen to have a valid image signature.
+    BufferedImage decoded;
+    try {
+      decoded = ImageIO.read(new ByteArrayInputStream(content));
+    } catch (IOException e) {
+      decoded = null;
+    }
+    if (decoded == null) {
+      LogHelper.info(logger, "File could not be decoded as a valid image.");
+      throw new InvalidImageFormatException("File is not a valid image.");
     }
 
     // **Sanitize userRequestId  to prevent path traversal**
@@ -83,7 +104,7 @@ public class ImageService {
     String filePath = requestUploadDir + uniqueFilename;
     LogHelper.info(logger, "Saving image {0} for request {1} in directory {2}",
         uniqueFilename, userRequestId, requestUploadDir);
-    Files.copy(file.getInputStream(), new File(filePath).toPath(), StandardCopyOption.REPLACE_EXISTING);
+    Files.write(new File(filePath).toPath(), content);
 
     return uniqueFilename;
   }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/service/ImageService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/service/ImageService.java
@@ -28,7 +28,7 @@ public class ImageService {
 
   private static final String UPLOAD_DIR = "uploads/";
   private static final List<String> ALLOWED_MIME_TYPES = List.of(MediaType.IMAGE_JPEG_VALUE, MediaType.IMAGE_PNG_VALUE);
-  private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB limit
+  private static final long MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB limit
   private static final Logger logger = Logger.getLogger(ImageService.class.getName());
   private static final String REGEX_SANITIZE = "[^a-zA-Z0-9_-]";
   private static final Tika TIKA = new Tika();
@@ -59,7 +59,7 @@ public class ImageService {
     // **Check file size**
     if (file.getSize() > MAX_FILE_SIZE) {
       LogHelper.info(logger, "File is too large. Max allowed size is {0}MB and the file was {1}MB", MAX_FILE_SIZE / (1024 * 1024), file.getSize() / (1024 * 1024));
-      throw new ImageProcessingException("File is too large. Max allowed size is 10MB.");
+      throw new ImageProcessingException("File is too large. Max allowed size is 50MB.");
     }
 
     byte[] content = file.getBytes();

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/service/MessageService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/service/MessageService.java
@@ -9,7 +9,6 @@ import ntnu.idi.mushroomidentificationbackend.exception.DatabaseOperationExcepti
 import ntnu.idi.mushroomidentificationbackend.mapper.MessageMapper;
 import ntnu.idi.mushroomidentificationbackend.model.entity.Message;
 import ntnu.idi.mushroomidentificationbackend.model.entity.UserRequest;
-import ntnu.idi.mushroomidentificationbackend.model.enums.UserRequestStatus;
 import ntnu.idi.mushroomidentificationbackend.repository.MessageRepository;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -39,10 +38,9 @@ public class MessageService {
   }
 
   /**
-   * Save a new message to the database.
-   * This method checks if the user request is not completed before saving the message.
-   * If the user request is completed,
-   * it throws a DatabaseOperationException.
+   * Save a new message to the database. Allowed on completed requests too - a
+   * completed request can still receive follow-up messages, it just stays
+   * completed rather than reopening (see UserRequestService#updateProjectAfterMessage).
    *
    * @param messageDTO The DTO containing the message details to be saved.
    * @param userRequestId The ID of the user request to which the message belongs.
@@ -50,11 +48,7 @@ public class MessageService {
    */
   public MessageDTO saveMessage(NewMessageDTO messageDTO, String userRequestId) {
     UserRequest userRequest = userRequestService.getUserRequest(userRequestId);
-    
-    if (userRequest.getStatus() == UserRequestStatus.COMPLETED) {
-      throw new DatabaseOperationException("Cannot add message to a completed user request");
-    }
-    
+
     Message message = MessageMapper.fromDtoToEntity(messageDTO, userRequest);
     Message savedMessage = messageRepository.save(message);
     return MessageMapper.fromEntityToDto(savedMessage);

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/service/MushroomService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/service/MushroomService.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import ntnu.idi.mushroomidentificationbackend.dto.request.AddImagesToMushroomDTO;
 import ntnu.idi.mushroomidentificationbackend.dto.request.UpdateMushroomStatusDTO;
 import ntnu.idi.mushroomidentificationbackend.dto.response.MushroomDTO;
@@ -16,6 +18,7 @@ import ntnu.idi.mushroomidentificationbackend.model.entity.Image;
 import ntnu.idi.mushroomidentificationbackend.model.entity.Mushroom;
 import ntnu.idi.mushroomidentificationbackend.model.entity.UserRequest;
 import ntnu.idi.mushroomidentificationbackend.model.enums.BasketBadgeType;
+import ntnu.idi.mushroomidentificationbackend.model.enums.MushroomStatus;
 import ntnu.idi.mushroomidentificationbackend.repository.ImageRepository;
 import ntnu.idi.mushroomidentificationbackend.repository.MushroomRepository;
 import ntnu.idi.mushroomidentificationbackend.repository.UserRequestRepository;
@@ -200,9 +203,24 @@ public class MushroomService {
     return badges;
   }
 
+  /**
+   * Counts the mushrooms of a user request by their status, for building a per-request
+   * decision summary (e.g. "Psilocybin and 3 more") on the admin request tables.
+   *
+   * @param userRequestId the ID of the user request that the mushrooms are connected to
+   * @return a map of mushroom status to the number of mushrooms with that status
+   */
+  public Map<MushroomStatus, Long> getMushroomStatusCounts(String userRequestId) {
+    Optional<UserRequest> userRequestOpt = userRequestRepository.findByUserRequestId(userRequestId);
+    if (userRequestOpt.isEmpty()) return Map.of();
+
+    List<Mushroom> mushrooms = mushroomRepository.findByUserRequest(userRequestOpt);
+    return mushrooms.stream()
+        .collect(Collectors.groupingBy(Mushroom::getMushroomStatus, Collectors.counting()));
+  }
 
   /**
-   * Adds images to a mushroom. 
+   * Adds images to a mushroom.
    * Saves the images locally and adds the image URLs to the mushroom entity.
    *
    * @param userRequestId id for the user request that the mushroom is connected to

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/service/StatsService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/service/StatsService.java
@@ -328,7 +328,7 @@ public class StatsService {
     );
   
     StringBuilder csv = new StringBuilder();
-    csv.append("Request ID,Status,Updated At,Mushroom Count\n");
+    csv.append("Request ID,Status,Updated at,Mushroom count\n");
   
     for (UserRequest request : requests) {
       String requestId = request.getUserRequestId();
@@ -391,11 +391,11 @@ public class StatsService {
 
     // Add Title and Dates
     String monthName = start.getMonth().getDisplayName(TextStyle.FULL, Locale.ENGLISH);
-    Paragraph title = new Paragraph("Monthly Report - " + monthName + " " + year, FontFactory.getFont(FontFactory.HELVETICA_BOLD, 16));
+    Paragraph title = new Paragraph("Monthly report - " + monthName + " " + year, FontFactory.getFont(FontFactory.HELVETICA_BOLD, 16));
     title.setAlignment(Element.ALIGN_CENTER);
     doc.add(title);
 
-    Paragraph exportDate = new Paragraph("Export Date: " + LocalDate.now().toString(), FontFactory.getFont(FontFactory.HELVETICA, 10));
+    Paragraph exportDate = new Paragraph("Export date: " + LocalDate.now().toString(), FontFactory.getFont(FontFactory.HELVETICA, 10));
     exportDate.setAlignment(Element.ALIGN_RIGHT);
     doc.add(exportDate);
 
@@ -404,21 +404,21 @@ public class StatsService {
     // Summary Table
     PdfPTable summary = new PdfPTable(2);
     summary.setWidthPercentage(100);
-    summary.addCell("New Requests");
+    summary.addCell("New requests");
     summary.addCell(String.valueOf(newRequests));
-    summary.addCell("Completed Requests");
+    summary.addCell("Completed requests");
     summary.addCell(String.valueOf(completedRequests));
-    summary.addCell("FTR Clicks");
+    summary.addCell("FTR clicks");
     summary.addCell(String.valueOf(ftrClicks));
-    summary.addCell("Psilocybin Identified");
+    summary.addCell("Psilocybin identified");
     summary.addCell(String.valueOf(psilocybin));
-    summary.addCell("Non-Psilocybin Identified");
+    summary.addCell("Non-psilocybin identified");
     summary.addCell(String.valueOf(nonPsilocybin));
-    summary.addCell("Toxic Identified");
+    summary.addCell("Toxic identified");
     summary.addCell(String.valueOf(toxic));
-    summary.addCell("Unknown Identified");
+    summary.addCell("Unknown identified");
     summary.addCell(String.valueOf(unknown));
-    summary.addCell("Unidentifiable Identified");
+    summary.addCell("Unidentifiable identified");
     summary.addCell(String.valueOf(unidentifiable));
     doc.add(summary);
 
@@ -429,8 +429,8 @@ public class StatsService {
     table.setWidthPercentage(100);
     table.addCell("Request ID");
     table.addCell("Status");
-    table.addCell("Updated At");
-    table.addCell("Mushroom Count");
+    table.addCell("Updated at");
+    table.addCell("Mushroom count");
 
     for (UserRequest request : requests) {
       String updatedAt = request.getUpdatedAt() != null

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestService.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 import lombok.AllArgsConstructor;
@@ -32,11 +33,13 @@ import ntnu.idi.mushroomidentificationbackend.repository.ImageRepository;
 import ntnu.idi.mushroomidentificationbackend.repository.MessageRepository;
 import ntnu.idi.mushroomidentificationbackend.repository.MushroomRepository;
 import ntnu.idi.mushroomidentificationbackend.repository.UserRequestRepository;
+import ntnu.idi.mushroomidentificationbackend.repository.UserRequestSpecifications;
 import ntnu.idi.mushroomidentificationbackend.security.ReferenceCodeGenerator;
 import ntnu.idi.mushroomidentificationbackend.security.SecretsConfig;
 import ntnu.idi.mushroomidentificationbackend.util.LogHelper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -181,21 +184,40 @@ public class UserRequestService {
         UserRequest userRequest = getUserRequest(userRequestId);
         long count = mushroomRepository.countByUserRequest(userRequest);
         List<BasketBadgeType> badges = mushroomService.getBasketSummaryBadges(userRequestId);
-        return UserRequestMapper.fromEntityToDto(userRequest, badges, count);
+        Map<MushroomStatus, Long> statusCounts = mushroomService.getMushroomStatusCounts(userRequestId);
+        return UserRequestMapper.fromEntityToDto(userRequest, badges, count, statusCounts);
     }
 
     /**
-     * Get a paginated list of user requests, ordered by updatedAt in descending order.
+     * Get a filtered, sorted list of user requests for the admin request tables.
      *
-     * @param pageable the pagination information
-     * @return a paginated list of UserRequestDTO objects
+     * @param status the status to filter by, or null to not filter by status
+     * @param exclude if true, excludes requests with the given status instead of requiring it;
+     *                ignored if status is null
+     * @param from the start of the createdAt range to filter by (inclusive), or null to not filter by date
+     * @param to the end of the createdAt range to filter by (inclusive), or null to not filter by date
+     * @param pageable the pagination and sort information; an unpaged Pageable returns every match in one page
+     * @return a page of UserRequestDTO objects matching the given filters
      */
-    public Page<UserRequestDTO> getPaginatedUserRequests(Pageable pageable) {
-        return userRequestRepository.findAllByOrderByUpdatedAtDesc(pageable)
+    public Page<UserRequestDTO> getFilteredUserRequests(UserRequestStatus status, boolean exclude,
+        Date from, Date to, Pageable pageable) {
+        Specification<UserRequest> spec = Specification.where(null);
+
+        if (status != null) {
+            spec = spec.and(exclude
+                ? UserRequestSpecifications.statusIsNot(status)
+                : UserRequestSpecifications.statusIs(status));
+        }
+        if (from != null && to != null) {
+            spec = spec.and(UserRequestSpecifications.createdBetween(from, to));
+        }
+
+        return userRequestRepository.findAll(spec, pageable)
             .map(req -> {
                 long count = mushroomRepository.countByUserRequest(req);
                 List<BasketBadgeType> badges = mushroomService.getBasketSummaryBadges(req.getUserRequestId());
-                return UserRequestMapper.fromEntityToDto(req, badges, count);
+                Map<MushroomStatus, Long> statusCounts = mushroomService.getMushroomStatusCounts(req.getUserRequestId());
+                return UserRequestMapper.fromEntityToDto(req, badges, count, statusCounts);
             });
     }
 
@@ -263,37 +285,6 @@ public class UserRequestService {
   }
 
     /**
-     * Get a paginated list of user requests by status.
-     * @param status the status of the user requests to filter by
-     * @param pageable the pagination information
-     * @return a paginated list of user requests with the specified status
-     */
-    public Page<UserRequestDTO> getPaginatedRequestsByStatus(UserRequestStatus status, Pageable pageable) {
-        return userRequestRepository.findAllByStatus(status, pageable)
-            .map(userRequest -> {
-                long count = mushroomRepository.countByUserRequest(userRequest);
-                List<BasketBadgeType> badges = mushroomService.getBasketSummaryBadges(userRequest.getUserRequestId());
-                return UserRequestMapper.fromEntityToDto(userRequest, badges, count);
-            });
-    }
-
-    /**
-     * Get a paginated list of user requests excluding a specific status.
-     * @param status the status to exclude from the results
-     * @param pageable the pagination information
-     * @return a paginated list of user requests excluding the specified status
-     */
-    public Page<UserRequestDTO> getPaginatedRequestsExcludingStatus(UserRequestStatus status, Pageable pageable) {
-        return userRequestRepository.findAllByStatusNot(status, pageable)
-            .map(userRequest -> {
-                long count = mushroomRepository.countByUserRequest(userRequest);
-                List<BasketBadgeType> badges = mushroomService.getBasketSummaryBadges(userRequest.getUserRequestId());
-                return UserRequestMapper.fromEntityToDto(userRequest, badges, count);
-            });
-    }
-
-
-    /**
      * Get the next request from the queue. Fetches the first user request with status NEW, ordered by
      * updatedAt in ascending order.
      *
@@ -306,7 +297,8 @@ public class UserRequestService {
         return userRequestOpt.map(userRequest -> {
             long count = mushroomRepository.countByUserRequest(userRequest);
             List<BasketBadgeType> badges = mushroomService.getBasketSummaryBadges(userRequest.getUserRequestId());
-            return UserRequestMapper.fromEntityToDto(userRequest, badges, count);
+            Map<MushroomStatus, Long> statusCounts = mushroomService.getMushroomStatusCounts(userRequest.getUserRequestId());
+            return UserRequestMapper.fromEntityToDto(userRequest, badges, count, statusCounts);
         }).orElse(null);
     }
 

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestService.java
@@ -356,4 +356,22 @@ public class UserRequestService {
             userRequestRepository.save(userRequest);
         }
     }
+
+    /**
+     * Forcibly releases a user request from whichever admin currently owns it and puts it
+     * back into the queue, regardless of who owns it. Unlike {@link #releaseRequestIfLockedByAdmin},
+     * this isn't gated on the caller being the current owner - it's a superuser-only escape hatch
+     * for reclaiming a request whose assigned moderator has stopped responding.
+     *
+     * @param userRequestId the ID of the user request to release
+     * @throws RequestNotFoundException if no such request exists
+     */
+    public void forceReleaseRequest(String userRequestId) {
+        UserRequest userRequest = getUserRequest(userRequestId);
+        userRequest.setAdmin(null);
+        if (userRequest.getStatus() == UserRequestStatus.IN_PROGRESS) {
+            userRequest.setStatus(UserRequestStatus.NEW);
+        }
+        userRequestRepository.save(userRequest);
+    }
 }

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestService.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestService.java
@@ -263,24 +263,29 @@ public class UserRequestService {
     }
 
     /**
-     * Update the status of a user request after a message is sent.
+     * Update a user request after a message is sent.
      * If the sender is a user and the status is PENDING, set it to NEW.
-     * Otherwise, do nothing.
+     * If the request is already COMPLETED, it stays completed - instead this
+     * tracks whether the user is waiting on a reply from the owning admin via
+     * hasFollowUp, set on a user message and cleared on an admin reply.
      *
      * @param userRequestId the ID of the user request
      * @param senderType the type of sender (user or admin)
      */
   public void updateProjectAfterMessage(String userRequestId, MessageSenderType senderType) {
         UserRequest userRequest = getUserRequest(userRequestId);
-        
-        if (userRequest.getStatus() == UserRequestStatus.COMPLETED) {
-            throw new DatabaseOperationException("Cannot update a completed user request");
-        }
         userRequest.setUpdatedAt(new Date());
+
+        if (userRequest.getStatus() == UserRequestStatus.COMPLETED) {
+            userRequest.setHasFollowUp(senderType == MessageSenderType.USER);
+            userRequestRepository.save(userRequest);
+            return;
+        }
+
         // If the sender is a user and the status is PENDING, set it to NEW
         if (senderType == MessageSenderType.USER && userRequest.getStatus() == UserRequestStatus.PENDING) {
             userRequest.setStatus(UserRequestStatus.NEW);
-        } 
+        }
         userRequestRepository.save(userRequest);
   }
 

--- a/src/main/java/ntnu/idi/mushroomidentificationbackend/task/GarbageCollectionTask.java
+++ b/src/main/java/ntnu/idi/mushroomidentificationbackend/task/GarbageCollectionTask.java
@@ -40,17 +40,17 @@ public class GarbageCollectionTask {
 
     /**
      * Runs daily at 02:00.
-     * Scans the local 'uploads/' directory for any request‐ID folders
+     * Scans the local 'uploads/' directory for any request-ID folders
      * that no longer exist in the database and deletes them.
      */
     @Scheduled(cron = "${orphan.images.cron.expression:0 0 2 * * *}")
     public void cleanupOrphanImageDirectories() {
         try {
-            LogHelper.info(logger, "Starting orphan‐image‐directory cleanup task...");
+            LogHelper.info(logger, "Starting orphan-image-directory cleanup task...");
             garbageCollectionService.cleanupOrphanImageDirs();
-            LogHelper.info(logger, "Orphan‐image‐directory cleanup completed successfully.");
+            LogHelper.info(logger, "Orphan-image-directory cleanup completed successfully.");
         } catch (Exception e) {
-            LogHelper.severe(logger, "Error during orphan‐image cleanup: {0}", e.getMessage());
+            LogHelper.severe(logger, "Error during orphan-image cleanup: {0}", e.getMessage());
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,3 +59,11 @@ management.endpoint.health.probes.enabled=true
 
 app.secrets.secret-key=${SECRET_KEY}
 app.secrets.lookup-salt=${LOOKUP_SALT}
+
+# Don't leak stack traces, exception messages, or binding errors in error responses -
+# GlobalExceptionHandler covers the exceptions our own code raises, but this covers
+# anything that reaches Spring Boot's default error page first (e.g. a 404).
+server.error.include-stacktrace=never
+server.error.include-exception=false
+server.error.include-message=never
+server.error.include-binding-errors=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,10 +35,10 @@ orphan.images.cron.expression=0 0 2 1 * *
 # Move statistics to archive at  midnight on the 1st of every month
 statistics.archive.cron.expression=0 0 0 1 * *
 
-# Allowed browser origins, comma separated. Defaults to the Vite dev server.
-# In production this is set through the CORS_ALLOWED_ORIGINS environment variable,
-# e.g. CORS_ALLOWED_ORIGINS=https://fleinsoppkontroll.no
-app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173}
+# Allowed browser origins, comma separated. Defaults to this deployment's real
+# production domain; override via the CORS_ALLOWED_ORIGINS environment
+# variable for other environments, e.g. CORS_ALLOWED_ORIGINS=http://localhost:5173
+app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:https://fleinkontroll.mooo.com}
 
 # Trust X-Forwarded-* headers so the app sees the public scheme and host when it
 # runs behind a reverse proxy or a Cloudflare tunnel. Without this, redirects and

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,11 +45,12 @@ app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:https://fleinkontroll.mooo.com}
 # SockJS negotiation can hand out http:// URLs to an https:// client.
 server.forward-headers-strategy=FRAMEWORK
 
-# Multipart limits. ImageService rejects anything above 10MB per file, but the
-# servlet limits apply first and default to 1MB per file / 10MB per request,
-# which is smaller than a typical phone photo.
-spring.servlet.multipart.max-file-size=10MB
-spring.servlet.multipart.max-request-size=60MB
+# Multipart limits. ImageService rejects anything above 50MB per file, but the
+# servlet limits apply first and default to 1MB per file / 10MB per request.
+# Set generously above what the frontend's own downscaling should ever produce
+# (a few MB at most) so a large source photo can never fail the upload outright.
+spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=200MB
 
 # Expose only the health endpoint, used by the container healthcheck.
 management.endpoints.web.exposure.include=health

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/admin/AdminUserRequestControllerTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/admin/AdminUserRequestControllerTest.java
@@ -56,7 +56,7 @@ class AdminUserRequestControllerTest {
   @Test
   void getAllRequestsPaginated_returnsPage() throws Exception {
     Page<UserRequestDTO> page = new PageImpl<>(Collections.singletonList(new UserRequestDTO()));
-    when(userRequestService.getPaginatedUserRequests(any())).thenReturn(page);
+    when(userRequestService.getFilteredUserRequests(any(), anyBoolean(), any(), any(), any())).thenReturn(page);
 
     mockMvc.perform(get("/api/admin/requests"))
         .andExpect(status().isOk());

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/admin/AdminUserRequestControllerTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/admin/AdminUserRequestControllerTest.java
@@ -98,6 +98,16 @@ class AdminUserRequestControllerTest {
   }
 
   @Test
+  void releaseRequest_callsServiceAndNotifiesObservers() throws Exception {
+    mockMvc.perform(post("/api/admin/requests/id1/release"))
+        .andExpect(status().isOk());
+
+    verify(userRequestService).forceReleaseRequest("id1");
+    verify(webSocketNotificationHandler, times(2))
+        .sendRequestUpdateToObservers(eq("id1"), any());
+  }
+
+  @Test
   void getNextRequestFromQueue_returnsRequestOrNoContent() throws Exception {
     when(userRequestService.getNextRequestFromQueue()).thenReturn(new UserRequestDTO());
 

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestControllerTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestControllerTest.java
@@ -59,7 +59,7 @@ class UserRequestControllerTest {
   void getRequest_returnsUserRequestDTO() throws Exception {
     String token = "Bearer testtoken";
     String requestId = "abc123";
-    UserRequestDTO dto = new UserRequestDTO(requestId, new Date(), new Date(), null, 3, null, null, null);
+    UserRequestDTO dto = new UserRequestDTO(requestId, new Date(), new Date(), null, 3, null, null, null, false);
 
     when(jwtUtil.extractUsername("testtoken")).thenReturn(requestId);
     when(userRequestService.getUserRequestDTO(requestId)).thenReturn(dto);

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestControllerTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestControllerTest.java
@@ -1,16 +1,19 @@
 package ntnu.idi.mushroomidentificationbackend.controller.api;
 
 import ntnu.idi.mushroomidentificationbackend.dto.response.UserRequestDTO;
+import ntnu.idi.mushroomidentificationbackend.handler.GlobalExceptionHandler;
 import ntnu.idi.mushroomidentificationbackend.handler.WebSocketNotificationHandler;
 import ntnu.idi.mushroomidentificationbackend.model.enums.WebsocketNotificationType;
 import ntnu.idi.mushroomidentificationbackend.security.JWTUtil;
 import ntnu.idi.mushroomidentificationbackend.security.SecurityConfigDev;
 import ntnu.idi.mushroomidentificationbackend.service.UserRequestService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,6 +22,7 @@ import java.util.Date;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -27,7 +31,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = {
     UserRequestController.class,
     UserRequestControllerTest.TestConfig.class,
-    SecurityConfigDev.class
+    SecurityConfigDev.class,
+    GlobalExceptionHandler.class
 })
 class UserRequestControllerTest {
 
@@ -42,6 +47,13 @@ class UserRequestControllerTest {
   @Autowired private JWTUtil jwtUtil;
   @Autowired private UserRequestService userRequestService;
   @Autowired private WebSocketNotificationHandler webSocketNotificationHandler;
+
+  @BeforeEach
+  void resetMocks() {
+    // These mock beans live in a Spring test context cached across test methods, so previous
+    // tests' interactions must be cleared before asserting on interactions in a new test.
+    reset(jwtUtil, userRequestService, webSocketNotificationHandler);
+  }
 
   @Test
   void getRequest_returnsUserRequestDTO() throws Exception {
@@ -59,5 +71,34 @@ class UserRequestControllerTest {
 
     verify(webSocketNotificationHandler)
         .sendRequestUpdateToObservers(requestId, WebsocketNotificationType.USER_LOGGED_IN);
+  }
+
+  @Test
+  void createUserRequest_emptyRequest_returnsBadRequest() throws Exception {
+    mockMvc.perform(multipart("/api/requests/create"))
+        .andExpect(status().isBadRequest());
+
+    verify(userRequestService, never()).processNewUserRequest(any());
+  }
+
+  @Test
+  void createUserRequest_whitespaceOnlyTextAndNoMushrooms_returnsBadRequest() throws Exception {
+    mockMvc.perform(multipart("/api/requests/create").param("text", "   "))
+        .andExpect(status().isBadRequest());
+
+    verify(userRequestService, never()).processNewUserRequest(any());
+  }
+
+  @Test
+  void createUserRequest_validRequest_returnsReferenceCode() throws Exception {
+    MockMultipartFile image = new MockMultipartFile(
+        "mushrooms[0].images", "image.jpg", "image/jpeg", new byte[]{1, 2, 3});
+
+    when(userRequestService.processNewUserRequest(any())).thenReturn("REF-123");
+
+    mockMvc.perform(multipart("/api/requests/create")
+            .file(image)
+            .param("text", "Found this in the forest"))
+        .andExpect(status().isOk());
   }
 }

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestControllerTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestControllerTest.java
@@ -59,7 +59,7 @@ class UserRequestControllerTest {
   void getRequest_returnsUserRequestDTO() throws Exception {
     String token = "Bearer testtoken";
     String requestId = "abc123";
-    UserRequestDTO dto = new UserRequestDTO(requestId, new Date(), new Date(), null, 3, null, null);
+    UserRequestDTO dto = new UserRequestDTO(requestId, new Date(), new Date(), null, 3, null, null, null);
 
     when(jwtUtil.extractUsername("testtoken")).thenReturn(requestId);
     when(userRequestService.getUserRequestDTO(requestId)).thenReturn(dto);

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestControllerTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestControllerTest.java
@@ -100,5 +100,7 @@ class UserRequestControllerTest {
             .file(image)
             .param("text", "Found this in the forest"))
         .andExpect(status().isOk());
+
+    verify(webSocketNotificationHandler).sendAdminBroadcast(WebsocketNotificationType.NEW_REQUEST_IN_QUEUE);
   }
 }

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/auth/AuthenticationControllerTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/auth/AuthenticationControllerTest.java
@@ -3,7 +3,13 @@ package ntnu.idi.mushroomidentificationbackend.controller.auth;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ntnu.idi.mushroomidentificationbackend.dto.request.LoginRequestDTO;
 import ntnu.idi.mushroomidentificationbackend.dto.request.UserLoginDTO;
+import ntnu.idi.mushroomidentificationbackend.exception.TooManyRequestsException;
+import ntnu.idi.mushroomidentificationbackend.exception.UnauthorizedAccessException;
+import ntnu.idi.mushroomidentificationbackend.handler.GlobalExceptionHandler;
+import ntnu.idi.mushroomidentificationbackend.security.JWTUtil;
+import ntnu.idi.mushroomidentificationbackend.security.LoginAttemptService;
 import ntnu.idi.mushroomidentificationbackend.security.SecurityConfigDev;
+import ntnu.idi.mushroomidentificationbackend.security.TokenBlocklistService;
 import ntnu.idi.mushroomidentificationbackend.service.AuthenticationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,13 +31,17 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 @ContextConfiguration(classes = {
     AuthenticationController.class,
     AuthenticationControllerTest.TestConfig.class,
-    SecurityConfigDev.class
+    SecurityConfigDev.class,
+    LoginAttemptService.class,
+    GlobalExceptionHandler.class
 })
 class AuthenticationControllerTest {
 
   @Configuration
   static class TestConfig {
     @Bean public AuthenticationService authenticationService() { return mock(AuthenticationService.class); }
+    @Bean public JWTUtil jwtUtil() { return mock(JWTUtil.class); }
+    @Bean public TokenBlocklistService tokenBlocklistService() { return mock(TokenBlocklistService.class); }
   }
 
   @Autowired
@@ -67,5 +77,26 @@ class AuthenticationControllerTest {
             .content(objectMapper.writeValueAsString(userLoginDTO)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.token").value("userToken456"));
+  }
+
+  @Test
+  void adminLogin_repeatedFailures_isLockedOutWith429() throws Exception {
+    // Uses a username not touched by the other tests in this class, since LoginAttemptService
+    // state is shared across tests via the cached Spring test context.
+    LoginRequestDTO loginRequest = new LoginRequestDTO("attacker", "wrong");
+    when(authenticationService.authenticate("attacker", "wrong"))
+        .thenThrow(new UnauthorizedAccessException("Invalid username or password"));
+
+    for (int i = 0; i < 5; i++) {
+      mockMvc.perform(post("/auth/admin/login")
+              .contentType(APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(loginRequest)))
+          .andExpect(status().isUnauthorized());
+    }
+
+    mockMvc.perform(post("/auth/admin/login")
+            .contentType(APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(loginRequest)))
+        .andExpect(status().isTooManyRequests());
   }
 }

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/websocket/ChatWebSocketControllerTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/controller/websocket/ChatWebSocketControllerTest.java
@@ -6,6 +6,8 @@ import ntnu.idi.mushroomidentificationbackend.dto.response.MessageDTO;
 import ntnu.idi.mushroomidentificationbackend.handler.SessionRegistry;
 import ntnu.idi.mushroomidentificationbackend.handler.WebSocketErrorHandler;
 import ntnu.idi.mushroomidentificationbackend.handler.WebSocketNotificationHandler;
+import ntnu.idi.mushroomidentificationbackend.model.entity.UserRequest;
+import ntnu.idi.mushroomidentificationbackend.model.enums.UserRequestStatus;
 import ntnu.idi.mushroomidentificationbackend.model.enums.WebsocketNotificationType;
 import ntnu.idi.mushroomidentificationbackend.security.JWTUtil;
 import ntnu.idi.mushroomidentificationbackend.security.SecurityConfigDev;
@@ -56,6 +58,13 @@ class ChatWebSocketControllerTest {
   @Autowired
   private UserRequestService userRequestService;
 
+  @BeforeEach
+  void resetMocks() {
+    // These mock beans live in a Spring test context cached across test methods, so previous
+    // tests' interactions must be cleared before asserting on interactions in a new test.
+    reset(messageService, jwtUtil, messagingTemplate, webSocketNotificationHandler, userRequestService);
+  }
+
   @Test
   void handleMessage_validInput_sendsMessageAndNotifiesObservers() throws Exception {
     ChatWebSocketController controller = new ChatWebSocketController(
@@ -68,9 +77,13 @@ class ChatWebSocketControllerTest {
 
     MessageDTO response = new MessageDTO(null, ntnu.idi.mushroomidentificationbackend.model.enums.MessageSenderType.USER, "hello", new Date());
 
+    UserRequest userRequest = new UserRequest();
+    userRequest.setStatus(UserRequestStatus.NEW);
+
     when(jwtUtil.extractUsername(anyString())).thenReturn("user1");
     when(jwtUtil.extractRole(anyString())).thenReturn("MODERATOR");
     doNothing().when(jwtUtil).validateChatroomToken(anyString(), anyString());
+    when(userRequestService.getUserRequest("req123")).thenReturn(userRequest);
     when(messageService.saveMessage(any(), any())).thenReturn(response);
 
     controller.handleMessage("req123", "Bearer token123", "session1", dto);
@@ -79,5 +92,37 @@ class ChatWebSocketControllerTest {
     verify(userRequestService).updateProjectAfterMessage("req123", response.getSenderType());
     verify(messagingTemplate).convertAndSend(eq("/topic/chatroom/req123"), eq(response));
     verify(webSocketNotificationHandler).sendRequestUpdateToObservers("req123", WebsocketNotificationType.NEW_CHAT_MESSAGE);
+  }
+
+  @Test
+  void handleMessage_whenRequestAlreadyCompleted_skipsLockingButStillSendsAndNotifiesOwningAdmin() throws Exception {
+    ChatWebSocketController controller = new ChatWebSocketController(
+        messagingTemplate, messageService, userRequestService, jwtUtil,
+        mock(WebSocketErrorHandler.class), webSocketNotificationHandler
+    );
+
+    NewMessageDTO dto = new NewMessageDTO();
+    dto.setContent("Any updates?");
+
+    MessageDTO response = new MessageDTO(null, ntnu.idi.mushroomidentificationbackend.model.enums.MessageSenderType.USER, "Any updates?", new Date());
+
+    ntnu.idi.mushroomidentificationbackend.model.entity.Admin admin = new ntnu.idi.mushroomidentificationbackend.model.entity.Admin();
+    admin.setUsername("moderator1");
+
+    UserRequest userRequest = new UserRequest();
+    userRequest.setStatus(UserRequestStatus.COMPLETED);
+    userRequest.setAdmin(admin);
+
+    when(jwtUtil.extractUsername(anyString())).thenReturn("anonUser");
+    when(jwtUtil.extractRole(anyString())).thenReturn("USER");
+    doNothing().when(jwtUtil).validateChatroomToken(anyString(), anyString());
+    when(userRequestService.getUserRequest("req123")).thenReturn(userRequest);
+    when(messageService.saveMessage(any(), any())).thenReturn(response);
+
+    controller.handleMessage("req123", "Bearer token123", "session1", dto);
+
+    verify(userRequestService, never()).tryLockRequest(anyString(), anyString());
+    verify(messageService).saveMessage(dto, "req123");
+    verify(webSocketNotificationHandler).sendAlert(eq("moderator1"), anyString(), anyString());
   }
 }

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/security/WebSocketAuthInterceptorTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/security/WebSocketAuthInterceptorTest.java
@@ -17,12 +17,14 @@ import static org.mockito.Mockito.*;
 class WebSocketAuthInterceptorTest {
 
   private JWTUtil jwtUtil;
+  private TokenBlocklistService tokenBlocklistService;
   private WebSocketAuthInterceptor interceptor;
 
   @BeforeEach
   void setUp() {
     jwtUtil = mock(JWTUtil.class);
-    interceptor = new WebSocketAuthInterceptor(jwtUtil);
+    tokenBlocklistService = mock(TokenBlocklistService.class);
+    interceptor = new WebSocketAuthInterceptor(jwtUtil, tokenBlocklistService);
   }
 
   @Test

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/service/AuthenticationServiceTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/service/AuthenticationServiceTest.java
@@ -2,7 +2,6 @@ package ntnu.idi.mushroomidentificationbackend.service;
 
 import ntnu.idi.mushroomidentificationbackend.exception.RequestNotFoundException;
 import ntnu.idi.mushroomidentificationbackend.exception.UnauthorizedAccessException;
-import ntnu.idi.mushroomidentificationbackend.exception.UserNotFoundException;
 import ntnu.idi.mushroomidentificationbackend.model.entity.Admin;
 import ntnu.idi.mushroomidentificationbackend.model.entity.UserRequest;
 import ntnu.idi.mushroomidentificationbackend.model.enums.AdminRole;
@@ -53,9 +52,27 @@ class AuthenticationServiceTest {
   }
 
   @Test
-  void authenticate_invalidUsername_throwsUserNotFound() {
+  void authenticate_invalidUsername_throwsUnauthorized() {
     when(adminRepository.findByUsername("admin")).thenReturn(Optional.empty());
-    assertThrows(UserNotFoundException.class, () -> authenticationService.authenticate("admin", "password"));
+    assertThrows(UnauthorizedAccessException.class, () -> authenticationService.authenticate("admin", "password"));
+  }
+
+  @Test
+  void authenticate_invalidUsername_and_invalidPassword_giveSameMessage() {
+    Admin admin = new Admin();
+    admin.setUsername("admin");
+    admin.setPasswordHash("hashed-password");
+
+    when(adminRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+    when(passwordEncoder.matches(anyString(), anyString())).thenReturn(false);
+    when(adminRepository.findByUsername("ghost")).thenReturn(Optional.empty());
+
+    UnauthorizedAccessException unknownUserEx = assertThrows(UnauthorizedAccessException.class,
+        () -> authenticationService.authenticate("ghost", "password"));
+    UnauthorizedAccessException wrongPasswordEx = assertThrows(UnauthorizedAccessException.class,
+        () -> authenticationService.authenticate("admin", "wrong"));
+
+    assertEquals(unknownUserEx.getMessage(), wrongPasswordEx.getMessage());
   }
 
   @Test

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/service/ImageServiceTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/service/ImageServiceTest.java
@@ -1,6 +1,9 @@
 package ntnu.idi.mushroomidentificationbackend.service;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.lang.reflect.InvocationTargetException;
+import javax.imageio.ImageIO;
 import ntnu.idi.mushroomidentificationbackend.exception.ImageProcessingException;
 import ntnu.idi.mushroomidentificationbackend.exception.InvalidImageFormatException;
 import org.junit.jupiter.api.Test;
@@ -13,13 +16,20 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ImageServiceTest {
 
+  private static byte[] realJpegBytes() throws IOException {
+    BufferedImage image = new BufferedImage(4, 4, BufferedImage.TYPE_INT_RGB);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ImageIO.write(image, "jpg", out);
+    return out.toByteArray();
+  }
+
   @Test
   void saveImage_validImage_returnsFilename() throws IOException {
     MockMultipartFile file = new MockMultipartFile(
         "image",
         "image.jpg",
         MediaType.IMAGE_JPEG_VALUE,
-        new byte[1024]
+        realJpegBytes()
     );
 
     String result = ImageService.saveImage(file, "user123", "mushroom123");
@@ -42,6 +52,35 @@ class ImageServiceTest {
         "image.gif",
         MediaType.IMAGE_GIF_VALUE,
         new byte[1024]
+    );
+
+    assertThrows(InvalidImageFormatException.class, () ->
+        ImageService.saveImage(file, "user123", "mushroom123")
+    );
+  }
+
+  @Test
+  void saveImage_realImageWithSpoofedContentType_isAcceptedByRealContent() throws IOException {
+    // The client-supplied Content-Type is wrong/spoofed, but the actual bytes are a real JPEG.
+    // Content sniffing should look past the declared Content-Type and accept it.
+    MockMultipartFile file = new MockMultipartFile(
+        "image",
+        "image.jpg",
+        MediaType.APPLICATION_OCTET_STREAM_VALUE,
+        realJpegBytes()
+    );
+
+    String result = ImageService.saveImage(file, "user123", "mushroom123");
+    assertNotNull(result);
+  }
+
+  @Test
+  void saveImage_textFileDisguisedAsJpeg_throwsInvalidImageFormatException() {
+    MockMultipartFile file = new MockMultipartFile(
+        "image",
+        "fake.jpg",
+        MediaType.IMAGE_JPEG_VALUE,
+        "still not an image".getBytes()
     );
 
     assertThrows(InvalidImageFormatException.class, () ->

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/service/ImageServiceTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/service/ImageServiceTest.java
@@ -90,7 +90,7 @@ class ImageServiceTest {
 
   @Test
   void saveImage_fileTooLarge_throwsImageProcessingException() {
-    byte[] largeBytes = new byte[11 * 1024 * 1024]; // 11MB
+    byte[] largeBytes = new byte[51 * 1024 * 1024]; // 51MB
     MockMultipartFile file = new MockMultipartFile(
         "image",
         "large.jpg",

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/service/MessageServiceTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/service/MessageServiceTest.java
@@ -50,16 +50,21 @@ class MessageServiceTest {
   }
 
   @Test
-  void saveMessage_whenRequestCompleted_throwsException() {
+  void saveMessage_whenRequestCompleted_stillSavesAsAFollowUp() {
     UserRequest request = new UserRequest();
     request.setStatus(UserRequestStatus.COMPLETED);
-    when(userRequestService.getUserRequest("req1")).thenReturn(request);
 
     NewMessageDTO dto = new NewMessageDTO();
+    dto.setContent("Any updates?");
+    dto.setSenderType(MessageSenderType.USER);
 
-    assertThrows(DatabaseOperationException.class, () ->
-        messageService.saveMessage(dto, "req1")
-    );
+    Message entity = MessageMapper.fromDtoToEntity(dto, request);
+
+    when(userRequestService.getUserRequest("req1")).thenReturn(request);
+    when(messageRepository.save(any())).thenReturn(entity);
+
+    MessageDTO result = messageService.saveMessage(dto, "req1");
+    assertEquals(dto.getContent(), result.getContent());
   }
 
   @Test

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestServiceTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestServiceTest.java
@@ -2,7 +2,6 @@ package ntnu.idi.mushroomidentificationbackend.service;
 
 import ntnu.idi.mushroomidentificationbackend.dto.request.ChangeRequestStatusDTO;
 import ntnu.idi.mushroomidentificationbackend.dto.request.NewUserRequestDTO;
-import ntnu.idi.mushroomidentificationbackend.exception.DatabaseOperationException;
 import ntnu.idi.mushroomidentificationbackend.exception.RequestLockedException;
 import ntnu.idi.mushroomidentificationbackend.exception.RequestNotFoundException;
 import ntnu.idi.mushroomidentificationbackend.model.entity.Admin;
@@ -107,14 +106,30 @@ class UserRequestServiceTest {
   }
 
   @Test
-  void updateProjectAfterMessage_throwsIfCompleted() {
+  void updateProjectAfterMessage_whenCompletedAndUserReplies_setsFollowUpFlagWithoutChangingStatus() {
     UserRequest request = new UserRequest();
     request.setStatus(UserRequestStatus.COMPLETED);
     when(userRequestRepository.findByUserRequestId("123")).thenReturn(Optional.of(request));
 
-    assertThrows(DatabaseOperationException.class, () ->
-        userRequestService.updateProjectAfterMessage("123", MessageSenderType.USER)
-    );
+    userRequestService.updateProjectAfterMessage("123", MessageSenderType.USER);
+
+    assertEquals(UserRequestStatus.COMPLETED, request.getStatus());
+    assertTrue(request.isHasFollowUp());
+    verify(userRequestRepository).save(request);
+  }
+
+  @Test
+  void updateProjectAfterMessage_whenCompletedAndAdminReplies_clearsFollowUpFlag() {
+    UserRequest request = new UserRequest();
+    request.setStatus(UserRequestStatus.COMPLETED);
+    request.setHasFollowUp(true);
+    when(userRequestRepository.findByUserRequestId("123")).thenReturn(Optional.of(request));
+
+    userRequestService.updateProjectAfterMessage("123", MessageSenderType.ADMIN);
+
+    assertEquals(UserRequestStatus.COMPLETED, request.getStatus());
+    assertFalse(request.isHasFollowUp());
+    verify(userRequestRepository).save(request);
   }
 
   @Test

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestServiceTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestServiceTest.java
@@ -135,6 +135,22 @@ class UserRequestServiceTest {
   }
 
   @Test
+  void forceReleaseRequest_clearsOwnerAndReopensRegardlessOfOwner() {
+    UserRequest request = new UserRequest();
+    Admin owner = new Admin();
+    owner.setUsername("someModerator");
+    request.setAdmin(owner);
+    request.setStatus(UserRequestStatus.IN_PROGRESS);
+    when(userRequestRepository.findByUserRequestId("123")).thenReturn(Optional.of(request));
+
+    userRequestService.forceReleaseRequest("123");
+
+    assertNull(request.getAdmin());
+    assertEquals(UserRequestStatus.NEW, request.getStatus());
+    verify(userRequestRepository).save(request);
+  }
+
+  @Test
   void getFilteredUserRequests_returnsMappedResults() {
     UserRequest req = new UserRequest();
     req.setUserRequestId("123");

--- a/src/test/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestServiceTest.java
+++ b/src/test/java/ntnu/idi/mushroomidentificationbackend/service/UserRequestServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -134,16 +135,17 @@ class UserRequestServiceTest {
   }
 
   @Test
-  void getPaginatedUserRequests_returnsMappedResults() {
+  void getFilteredUserRequests_returnsMappedResults() {
     UserRequest req = new UserRequest();
     req.setUserRequestId("123");
     Page<UserRequest> page = new PageImpl<>(List.of(req));
 
-    when(userRequestRepository.findAllByOrderByUpdatedAtDesc(any())).thenReturn(page);
+    when(userRequestRepository.findAll(any(Specification.class), any(PageRequest.class))).thenReturn(page);
     when(mushroomRepository.countByUserRequest(req)).thenReturn(2L);
     when(mushroomService.getBasketSummaryBadges("123")).thenReturn(List.of());
+    when(mushroomService.getMushroomStatusCounts("123")).thenReturn(Map.of());
 
-    Page result = userRequestService.getPaginatedUserRequests(PageRequest.of(0, 10));
+    Page result = userRequestService.getFilteredUserRequests(null, false, null, null, PageRequest.of(0, 10));
     assertEquals(1, result.getTotalElements());
   }
 }


### PR DESCRIPTION
This pull request introduces several important improvements across security, API functionality, and documentation. The most significant changes include enhanced security for the embedded Tomcat server, new and improved authentication endpoints (including rate limiting and logout), expanded filtering and management options for user requests, and better validation and notification handling. Additionally, the documentation has been updated to reflect these changes and clarify usage.

**Security Enhancements**
- Added `TomcatServerInfoConfig` to prevent the embedded Tomcat server from disclosing its version and software information in error responses, reducing exposure to targeted attacks. (`src/main/java/ntnu/idi/mushroomidentificationbackend/config/TomcatServerInfoConfig.java`)
- Updated Docker entrypoint: now fixes ownership of `/app/uploads` at container startup and drops privileges before running application code, improving container security. (`Dockerfile`, `docker/entrypoint.sh`) [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R32-R45) [[2]](diffhunk://#diff-4f5cabe26761257a4d685a6edc7a43e0fe0f78762f50eeb48530f2bd3b3ee7caR1-R15)

**Authentication & Authorization Improvements**
- Implemented rate limiting for repeated failed admin login attempts to prevent brute-force attacks, and added a `/auth/logout` endpoint to allow JWT revocation before token expiry. (`src/main/java/ntnu/idi/mushroomidentificationbackend/controller/auth/AuthenticationController.java`) [[1]](diffhunk://#diff-8017473137ec951687e99adc1aecc2db6eeadb711ad4c199a2d7d6c5d2add5b0R3-R13) [[2]](diffhunk://#diff-8017473137ec951687e99adc1aecc2db6eeadb711ad4c199a2d7d6c5d2add5b0R27-R67) [[3]](diffhunk://#diff-8017473137ec951687e99adc1aecc2db6eeadb711ad4c199a2d7d6c5d2add5b0R98-R114)
- Updated documentation to describe new authentication behaviors and endpoints. (`README.md`)

**User Request Management Enhancements**
- Extended the admin user request listing endpoint to support filtering by status, date range, and exclusion, as well as unpaginated responses and custom sorting. (`src/main/java/ntnu/idi/mushroomidentificationbackend/controller/admin/AdminUserRequestController.java`)
- Added a superuser-only endpoint to forcibly release a user request from its current moderator, returning it to the queue. (`src/main/java/ntnu/idi/mushroomidentificationbackend/controller/admin/AdminUserRequestController.java`)

**Validation and Notification Improvements**
- Added request validation for new user requests and triggered admin notifications when a new request is created. (`src/main/java/ntnu/idi/mushroomidentificationbackend/controller/api/UserRequestController.java`, `pom.xml`) [[1]](diffhunk://#diff-669bdce23e79db919e1fe6eede1dc8c36b460e79237659b6aaa54ae8b719caa8R4) [[2]](diffhunk://#diff-669bdce23e79db919e1fe6eede1dc8c36b460e79237659b6aaa54ae8b719caa8L51-R55) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R43-R46)

**Documentation and Minor Updates**
- Improved and clarified documentation, including endpoint descriptions, code block formatting, and language consistency. (`README.md`, `.env.example`, `src/main/java/ntnu/idi/mushroomidentificationbackend/MushroomIdentificationBackendApplication.java`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R70) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L215-R216) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L226-R229) [[5]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL9-R9) [[6]](diffhunk://#diff-836d8bb671ba7692133d472f64ff431762d7cf51a25f5addad1317e49b82a794L26-R26)